### PR TITLE
Adopt meta-flutter repository changes

### DIFF
--- a/include/common-meta-dhsom-extras-flutter.yml
+++ b/include/common-meta-dhsom-extras-flutter.yml
@@ -11,3 +11,7 @@ local_conf_header:
 repos:
   meta-flutter:
     url: https://github.com/meta-flutter/meta-flutter.git
+        path: layers/meta-flutter
+    layers:
+      .:
+      meta-flutter-apps:

--- a/include/common-meta-dhsom-extras-flutter.yml
+++ b/include/common-meta-dhsom-extras-flutter.yml
@@ -11,7 +11,7 @@ local_conf_header:
 repos:
   meta-flutter:
     url: https://github.com/meta-flutter/meta-flutter.git
-        path: layers/meta-flutter
+    path: layers/meta-flutter
     layers:
       .:
       meta-flutter-apps:


### PR DESCRIPTION
meta-flutter now contains another layer meta-flutter-apps for all its app examples.